### PR TITLE
[PT-165307570] win32 native compilation

### DIFF
--- a/src/cuckoo/mean.hpp
+++ b/src/cuckoo/mean.hpp
@@ -256,9 +256,14 @@ public:
 
 #if NSIPHASH > 4
   void* operator new(size_t size) noexcept {
+#if !defined(_WIN32)
     void* newobj;
     int tmp = posix_memalign(&newobj, NSIPHASH * sizeof(u32), sizeof(edgetrimmer));
     if (tmp != 0) return nullptr;
+#else
+    void* newobj = _aligned_malloc(sizeof(edgetrimmer), NSIPHASH * sizeof(u32));
+    if (newobj == NULL) return nullptr;
+#endif
     return newobj;
   }
 #endif


### PR DESCRIPTION
This change fixes the cross-compilation in a msys2 environment for win32.